### PR TITLE
update apt first to avoid build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM r-base:latest
 
 MAINTAINER Winston Chang "winston@rstudio.com"
 
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
     sudo \
     gdebi-core \
     pandoc \


### PR DESCRIPTION
Docker recommends we update in the same layer as we call apt-get install otherwise we can get into trouble with caching, etc.  This should fix the build error.  

p.s. In case it's news: by default Docker Hub doesn't notify you when a build fails, but you can toggle these notifications on in: https://registry.hub.docker.com/account/notifications/