### PR TITLE
Bug fix: Shiny doesn't work with non-ascii files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,6 @@ EXPOSE 3838
 
 COPY shiny-server.sh /usr/bin/shiny-server.sh
 
+ENV LANG en_US.UTF-8
+
 CMD ["/usr/bin/shiny-server.sh"]


### PR DESCRIPTION
Example :

Error in source(file, ..., keep.source = TRUE, encoding = checkEncoding(file)) :
  /srv/shiny-server/server.R:21:28: unexpected INCOMPLETE_STRING
20:                                    icon = icon("bar-chart")),
21:                   menuItem("xxx
                               ^

Where   /srv/shiny-server/server.R:21:28 is xxxé