### PR TITLE
Redirect shiny-server output to file and stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This is a Dockerfile for Shiny Server on Debian "testing". It is based on the r-
 
 The image is available from [Docker Hub](https://registry.hub.docker.com/u/rocker/shiny/).
 
+As of January 2017, the Shiny Server log is written to `stdout` and can be viewed using `dockar logs`. The logs for individual apps are in the `/var/log/shiny-server` directory, as described in the [Shiny Server Administrator's Guide]( http://docs.rstudio.com/shiny-server/#application-error-logs)
+
 ## Usage:
 
 To run a temporary container with Shiny Server:
@@ -14,12 +16,12 @@ docker run --rm -p 3838:3838 rocker/shiny
 ```
 
 
-To expose a directory on the host to the container use `-v <host_dir>:<container_dir>`. The following command will use one `/srv/shinyapps` as the Shiny app directory and `/srv/shinylog` as the directory for logs. Note that if the directories on the host don't already exist, they will be created automatically.:
+To expose a directory on the host to the container use `-v <host_dir>:<container_dir>`. The following command will use one `/srv/shinyapps` as the Shiny app directory and `/srv/shinylog` as the directory for Shiny app logs. Note that if the directories on the host don't already exist, they will be created automatically.:
 
 ```sh
 docker run --rm -p 3838:3838 \
     -v /srv/shinyapps/:/srv/shiny-server/ \
-    -v /srv/shinylog/:/var/log/ \
+    -v /srv/shinylog/:/var/log/shiny-server/ \
     rocker/shiny
 ```
 
@@ -31,7 +33,7 @@ In a real deployment scenario, you will probably want to run the container in de
 ```sh
 docker run -d -p 80:3838 \
     -v /srv/shinyapps/:/srv/shiny-server/ \
-    -v /srv/shinylog/:/var/log/ \
+    -v /srv/shinylog/:/var/log/shiny-server/ \
     rocker/shiny
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a Dockerfile for Shiny Server on Debian "testing". It is based on the r-
 
 The image is available from [Docker Hub](https://registry.hub.docker.com/u/rocker/shiny/).
 
-As of January 2017, the Shiny Server log is written to `stdout` and can be viewed using `dockar logs`. The logs for individual apps are in the `/var/log/shiny-server` directory, as described in the [Shiny Server Administrator's Guide]( http://docs.rstudio.com/shiny-server/#application-error-logs)
+As of January 2017, the Shiny Server log is written to `stdout` and can be viewed using `docker logs`. The logs for individual apps are in the `/var/log/shiny-server` directory, as described in the [Shiny Server Administrator's Guide]( http://docs.rstudio.com/shiny-server/#application-error-logs)
 
 ## Usage:
 

--- a/shiny-server.sh
+++ b/shiny-server.sh
@@ -4,4 +4,4 @@
 mkdir -p /var/log/shiny-server
 chown shiny.shiny /var/log/shiny-server
 
-exec shiny-server 2>&1 | tee --append /var/log/shiny-server.log
+exec shiny-server 2>&1

--- a/shiny-server.sh
+++ b/shiny-server.sh
@@ -4,4 +4,4 @@
 mkdir -p /var/log/shiny-server
 chown shiny.shiny /var/log/shiny-server
 
-exec shiny-server >> /var/log/shiny-server.log 2>&1
+exec shiny-server 2>&1 | tee --append /var/log/shiny-server.log


### PR DESCRIPTION
It is useful to see the output of `shiny-server` at the stdout. This is especially the case when using Docker Compose. This patch makes the `shiny-server` output available to stdout as well.