### PR TITLE
Clean up after apt-get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y -t unstable \
     pandoc-citeproc \
     libcurl4-gnutls-dev \
     libcairo2-dev/unstable \
-    libxt-dev
+    libxt-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 # Download and install shiny server
 RUN wget --no-verbose https://s3.amazonaws.com/rstudio-shiny-server-os-build/ubuntu-12.04/x86_64/VERSION -O "version.txt" && \


### PR DESCRIPTION
It is generally recommended to clean-up after `apt-get`. This will reduce the image size and could avoid problems with `apt-get update`, like #18 and #19.