### PR TITLE
Clean up after apt-get (take 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM r-base:latest
 
 MAINTAINER Winston Chang "winston@rstudio.com"
 
+# Install dependencies and Download and install shiny server
 RUN apt-get update && apt-get install -y -t unstable \
     sudo \
     gdebi-core \
@@ -9,16 +10,15 @@ RUN apt-get update && apt-get install -y -t unstable \
     pandoc-citeproc \
     libcurl4-gnutls-dev \
     libcairo2-dev/unstable \
-    libxt-dev
-
-# Download and install shiny server
-RUN wget --no-verbose https://s3.amazonaws.com/rstudio-shiny-server-os-build/ubuntu-12.04/x86_64/VERSION -O "version.txt" && \
+    libxt-dev && \
+    wget --no-verbose https://s3.amazonaws.com/rstudio-shiny-server-os-build/ubuntu-12.04/x86_64/VERSION -O "version.txt" && \
     VERSION=$(cat version.txt)  && \
     wget --no-verbose "https://s3.amazonaws.com/rstudio-shiny-server-os-build/ubuntu-12.04/x86_64/shiny-server-$VERSION-amd64.deb" -O ss-latest.deb && \
     gdebi -n ss-latest.deb && \
     rm -f version.txt ss-latest.deb && \
     R -e "install.packages(c('shiny', 'rmarkdown'), repos='https://cran.rstudio.com/')" && \
-    cp -R /usr/local/lib/R/site-library/shiny/examples/* /srv/shiny-server/
+    cp -R /usr/local/lib/R/site-library/shiny/examples/* /srv/shiny-server/ && \
+    rm -rf /var/lib/apt/lists/*
 
 EXPOSE 3838
 


### PR DESCRIPTION
Install dependencies and shiny in one Docker command. This allows for cleaning after `apt-get` (`rm -rf /var/lib/apt/lists/*`) but not before `gdebi` which requires the apt cache. See https://github.com/rocker-org/shiny/pull/22#issuecomment-275166413

This is an improvement over #22 which created problems. It should fix #19.
