### PR TITLE
adding the application logs to the stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     libcurl4-gnutls-dev \
     libcairo2-dev \
     libxt-dev \
+    xtail \
     wget
 
 # Download and install shiny server

--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ If you have an app in `mountpoints/apps/appdir`, you can run the app by visiting
 
 The example `docker-compose` file will create a persistent volume for server logs, so that log data will persist across instances where the container is running. To access these logs, while the container is running, run `docker exec -it shiny bash` and then `ls /var/log/shiny-server` to see the available logs. To copy these logs to the host system for inspection, while the container is running, you can use, for example, `docker cp shiny:/var/log/shiny-server ./logs_for_inspection`.
 
+#### Push all aplication logs to STDOUT
+
+> This is experimental feature. Use it on your own risk!
+
+Original shiny-server does not have an option to push all the logs to STDOUT, however the Docker best practices highly recommend that.
+
+However, technically, there is a workaround to listen to filesystem events in the logs folder and push them to STDOUT.
+
+To enable this mode set `APPLICATION_LOGS_TO_STDOUT` to `true`.
+
+```sh
+docker run -it -e APPLICATION_LOGS_TO_STDOUT=true -p 3838:3838 shiny-local
+```
+
 #### Detached mode
 
 In a real deployment scenario, you will probably want to run the container in detached mode (`-d`):

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ docker run --user shiny -p 3838:3838 --rm rocker/shiny
 
 ### Logs
 
-As of January 2017, the Shiny Server log is written to `stdout` and can be viewed using `docker logs`. The logs for individual apps are in the `/var/log/shiny-server` directory, as described in the [Shiny Server Administrator's Guide]( http://docs.rstudio.com/shiny-server/#application-error-logs)
+The Shiny Server log and all application logs are written to `stdout` and can be viewed using `docker logs`.
+
+The logs for individual apps are still kept in the `/var/log/shiny-server` directory, as described in the [Shiny Server Administrator's Guide]( http://docs.rstudio.com/shiny-server/#application-error-logs). If you want to avoid printing the logs to STDOUT, set up the environment variable `APPLICATION_LOGS_TO_STDOUT` to `false` (`-e APPLICATION_LOGS_TO_STDOUT=false`).
+
 
 ### With docker-compose
 
@@ -76,20 +79,6 @@ If you have an app in `mountpoints/apps/appdir`, you can run the app by visiting
 #### Logs
 
 The example `docker-compose` file will create a persistent volume for server logs, so that log data will persist across instances where the container is running. To access these logs, while the container is running, run `docker exec -it shiny bash` and then `ls /var/log/shiny-server` to see the available logs. To copy these logs to the host system for inspection, while the container is running, you can use, for example, `docker cp shiny:/var/log/shiny-server ./logs_for_inspection`.
-
-#### Push all aplication logs to STDOUT
-
-> This is experimental feature. Use it on your own risk!
-
-Original shiny-server does not have an option to push all the logs to STDOUT, however the Docker best practices highly recommend that.
-
-However, technically, there is a workaround to listen to filesystem events in the logs folder and push them to STDOUT.
-
-To enable this mode set `APPLICATION_LOGS_TO_STDOUT` to `true`.
-
-```sh
-docker run -it -e APPLICATION_LOGS_TO_STDOUT=true -p 3838:3838 shiny-local
-```
 
 #### Detached mode
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
     # run on the localhost:80 "Welcome to Shiny" diagnostics page mentioned
     # below.
     user: 'root'
+    # Uncomment the lines below to disable application logs STDOUT output
+    # environment:
+    #   - APPLICATION_LOGS_TO_STDOUT=false
     ports:
       - '80:3838'
     volumes:

--- a/shiny-server.sh
+++ b/shiny-server.sh
@@ -4,15 +4,13 @@
 mkdir -p /var/log/shiny-server
 chown shiny.shiny /var/log/shiny-server
 
-if [ "$APPLICATION_LOGS_TO_STDOUT" = "true" ];
+if [ "$APPLICATION_LOGS_TO_STDOUT" = "false" ];
 then
-    echo "All application logs will be printed to STDOUT"
-
+    exec shiny-server 2>&1
+else
     # start shiny server in detached mode
     exec shiny-server 2>&1 &
 
     # push the "real" application logs to stdout with xtail
     exec xtail /var/log/shiny-server/
-else
-    exec shiny-server 2>&1
 fi

--- a/shiny-server.sh
+++ b/shiny-server.sh
@@ -4,8 +4,15 @@
 mkdir -p /var/log/shiny-server
 chown shiny.shiny /var/log/shiny-server
 
-# start shiny server in detached mode
-exec shiny-server 2>&1 &
+if [ "$APPLICATION_LOGS_TO_STDOUT" = "true" ];
+then
+    echo "All application logs will be printed to STDOUT"
 
-# push the "real" application logs to stdout with xtail
-exec xtail /var/log/shiny-server/
+    # start shiny server in detached mode
+    exec shiny-server 2>&1 &
+
+    # push the "real" application logs to stdout with xtail
+    exec xtail /var/log/shiny-server/
+else
+    exec shiny-server 2>&1
+fi

--- a/shiny-server.sh
+++ b/shiny-server.sh
@@ -4,4 +4,8 @@
 mkdir -p /var/log/shiny-server
 chown shiny.shiny /var/log/shiny-server
 
-exec shiny-server 2>&1
+# start shiny server in detached mode
+exec shiny-server 2>&1 &
+
+# push the "real" application logs to stdout with xtail
+exec xtail /var/log/shiny-server/


### PR DESCRIPTION
The application logs should go to stdout to conform the docker as a service requirements.

E.g. when the container gets deployed to the Kubernetes cluster, the logs become inaccessible. Developing locally is also painful because the logs get removed all the time etc.

The solution presented here is not ideal, however it solves the main problem: logs are written to stdout.

You can test the solution from my branch by

```sh
docker build -t shiny-local .
...
docker run -p 3838:3838 shiny-local
```

