### PR TITLE
added xtail to all the Dockerfiles for previous R versions

### DIFF
--- a/3.3.1/Dockerfile
+++ b/3.3.1/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
     libcurl4-gnutls-dev \
     libcairo2-dev \
     libxt-dev \
+    xtail \
     wget
 
 # Download and install shiny server

--- a/3.3.2/Dockerfile
+++ b/3.3.2/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
     libcurl4-gnutls-dev \
     libcairo2-dev \
     libxt-dev \
+    xtail \
     wget
 
 

--- a/3.3.3/Dockerfile
+++ b/3.3.3/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     libcurl4-gnutls-dev \
     libcairo2-dev \
     libxt-dev \
+    xtail \
     wget
 
 # Download and install shiny server

--- a/3.4.0/Dockerfile
+++ b/3.4.0/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     libcurl4-gnutls-dev \
     libcairo2-dev \
     libxt-dev \
+    xtail \
     wget
 
 

--- a/3.4.1/Dockerfile
+++ b/3.4.1/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     libcurl4-gnutls-dev \
     libcairo2-dev \
     libxt-dev \
+    xtail \
     wget
 
 

--- a/3.4.2/Dockerfile
+++ b/3.4.2/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     libcurl4-gnutls-dev \
     libcairo2-dev \
     libxt-dev \
+    xtail \
     wget
 
 

--- a/3.4.3/Dockerfile
+++ b/3.4.3/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     libcurl4-gnutls-dev \
     libcairo2-dev \
     libxt-dev \
+    xtail \
     wget
 
 

--- a/3.4.4/Dockerfile
+++ b/3.4.4/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     libcurl4-gnutls-dev \
     libcairo2-dev \
     libxt-dev \
+    xtail \
     wget
 
 

--- a/3.5.0/Dockerfile
+++ b/3.5.0/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     libcurl4-gnutls-dev \
     libcairo2-dev \
     libxt-dev \
+    xtail \
     wget
 
 

--- a/3.5.1/Dockerfile
+++ b/3.5.1/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     libcurl4-gnutls-dev \
     libcairo2-dev \
     libxt-dev \
+    xtail \
     wget
 
 


### PR DESCRIPTION
Noticed that xtail is used in all the shiny-server.sh for old R versions. However, it was only added to the main Dockerfile, not to the Dockerfiles belonging to the old versions. Added it to all of them.