### PR TITLE
Fix stopping container with running xtail

### DIFF
--- a/shiny-server.sh
+++ b/shiny-server.sh
@@ -4,13 +4,11 @@
 mkdir -p /var/log/shiny-server
 chown shiny.shiny /var/log/shiny-server
 
-if [ "$APPLICATION_LOGS_TO_STDOUT" = "false" ];
+if [ "$APPLICATION_LOGS_TO_STDOUT" != "false" ];
 then
-    exec shiny-server 2>&1
-else
-    # start shiny server in detached mode
-    exec shiny-server 2>&1 &
-
-    # push the "real" application logs to stdout with xtail
-    exec xtail /var/log/shiny-server/
+    # push the "real" application logs to stdout with xtail in detached mode
+    exec xtail /var/log/shiny-server/ &
 fi
+
+# start shiny server
+exec shiny-server 2>&1


### PR DESCRIPTION
Running `xterm` in foreground and `shiny-server` in background lead to broken container shutdown on SIGTERM signal (ctrl-c). 

Compare execution without `xterm`:
```
$ docker container run --rm -it -e APPLICATION_LOGS_TO_STDOUT=false   -p 3838:3838 rocker/shiny-verse:latest
[2019-04-22T04:33:18.211] [INFO] shiny-server - Shiny Server v1.5.11.924 (Node.js v8.11.3)
[2019-04-22T04:33:18.220] [INFO] shiny-server - Using config file "/etc/shiny-server/shiny-server.conf"
[2019-04-22T04:33:18.360] [WARN] shiny-server - Running as root unnecessarily is a security risk! You could be running more securely as non-root.
[2019-04-22T04:33:18.377] [INFO] shiny-server - Starting listener on http://[::]:3838
^C[2019-04-22T04:33:22.984] [INFO] shiny-server - Stopping listener on http://[::]:3838
[2019-04-22T04:33:22.985] [INFO] shiny-server - Shutting down worker processes (with notification)
$
```

and with `xterm`:
```
$ docker container run --rm -it -p 3838:3838 rocker/shiny-verse:latest

*** warning - no files are being watched ***
[2019-04-22T04:41:46.432] [INFO] shiny-server - Shiny Server v1.5.11.924 (Node.js v8.11.3)
[2019-04-22T04:41:46.436] [INFO] shiny-server - Using config file "/etc/shiny-server/shiny-server.conf"
[2019-04-22T04:41:46.540] [WARN] shiny-server - Running as root unnecessarily is a security risk! You could be running more securely as non-root.
[2019-04-22T04:41:46.549] [INFO] shiny-server - Starting listener on http://[::]:3838
^C
*** recently changed files ***
currently watching:  0 files  1 dirs  0 unknown entries
[2019-04-22T04:41:49.925] [INFO] shiny-server - Stopping listener on http://[::]:3838
[2019-04-22T04:41:49.925] [INFO] shiny-server - Shutting down worker processes (with notification)
^C(note: use "ctrl-\" SIQUIT to exit program)

*** recently changed files ***
currently watching:  0 files  1 dirs  0 unknown entries
^C(note: use "ctrl-\" SIQUIT to exit program)

*** recently changed files ***
currently watching:  0 files  1 dirs  0 unknown entries
^C(note: use "ctrl-\" SIQUIT to exit program)

*** recently changed files ***
currently watching:  0 files  1 dirs  0 unknown entries
^\
$
```

The patch always exec shiny-server as container's main process and run `xtail` in background. So, both processes stop on SIGTERM as expected.