### PR TITLE
Bumped to r-ver 3.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:3.6.1
+FROM rocker/r-ver:3.6.2
 
 RUN apt-get update && apt-get install -y \
     sudo \


### PR DESCRIPTION
As in #71, this updates the base image and pulls in the new shiny-server version 1.5.13.944.

This builds fine with `docker compose up --build`. 

Since I'm now anyway having the fork: What about #64 and #68? We could address them right away?